### PR TITLE
Tarun, Vinisha | MOBN-1522 | BAH-1017 | Fix issue in form conditions editor

### DIFF
--- a/src/form-builder/components/FormDetailContainer.jsx
+++ b/src/form-builder/components/FormDetailContainer.jsx
@@ -39,7 +39,6 @@ export class FormDetailContainer extends Component {
   constructor(props) {
     super(props);
     this.timeoutId = undefined;
-    this.formJson = undefined;
     this.formPrivileges = undefined;
     this.state = {
       formData: undefined,
@@ -97,8 +96,7 @@ export class FormDetailContainer extends Component {
           referenceFormUuid: parsedFormValue.referenceFormUuid,
         });
         this._getFormPrivilegesFromDB(data.id, data.version);
-        this.formJson = this.getFormJson();
-        const formControlsArray = formHelper.getObsControlEvents(this.formJson);
+        const formControlsArray = formHelper.getObsControlEvents(parsedFormValue);
         this.props.dispatch(formLoad(formControlsArray));
       })
       .catch((error) => {


### PR DESCRIPTION
Issue fixed as part of this commit:

Preview tab was not working in few of the below scenarios as form conditions where not loaded correctly.
Broken scenarios:
1. Go to implementer interface, open any existing form and move to any other form.
2. Go to implementer interface, create new form with form control events and move to any other form.
3. Go to implementer interface, open any existing form, modify and save control events and move to any other form.

In any of the above scenarios form control events where not loaded correctly in form conditions editor and control events were not working in preview tab.