### PR TITLE
BAH-2162 | Fix. Path error for fonts folder in webpack configs

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -39,7 +39,7 @@ module.exports = {
     new ExtractTextPlugin('styles.css', { allChunks: true }),
     new CopyWebpackPlugin([
       {
-        from: path.join(__dirname, 'styles/fonts'), to: path.join(__dirname, '../dist/fonts'),
+        from: path.join(__dirname, 'styles/fonts'), to: path.join(__dirname, 'dist/fonts'),
       },
     ], { copyUnmodified: true }
     ),

--- a/webpack.test.config.js
+++ b/webpack.test.config.js
@@ -36,7 +36,7 @@ module.exports = {
     new ExtractTextPlugin('styles.css', { allChunks: true }),
     new CopyWebpackPlugin([
       {
-        from: path.join(__dirname, 'styles/fonts'), to: path.join(__dirname, '../dist/fonts'),
+        from: path.join(__dirname, 'styles/fonts'), to: path.join(__dirname, 'dist/fonts'),
       },
     ], { copyUnmodified: true }
     ),


### PR DESCRIPTION
This PR fixes the path of dist/fonts folder in webpack config which causes icons to be not loaded in the UI.