### PR TITLE
BAH-3161| Add. httpd:2.4.57-alpine As Docker Base Image

### DIFF
--- a/package/docker/Dockerfile
+++ b/package/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM httpd:2.4-alpine
+FROM httpd:2.4.57-alpine
 
 ADD dist/implementer_interface.zip /etc/implementer-interface/
 RUN unzip -d /usr/local/apache2/htdocs/implementer-interface /etc/implementer-interface/implementer_interface.zip


### PR DESCRIPTION
In this PR, the following modifications have been implemented:

**Base Image Update**: The base image `httpd` has been upgraded from version `2.4-alpine` to version `2.4.57-alpine`. 