### PR TITLE
BAH-3454 | Refactor. removed hardcoded locale in order to search for the concept in both user and default locale

### DIFF
--- a/src/form-builder/helpers/UrlHelper.js
+++ b/src/form-builder/helpers/UrlHelper.js
@@ -7,7 +7,7 @@ export class UrlHelper {
 
   getFullConceptRepresentation(conceptName) {
     return '/openmrs/ws/rest/v1/concept?' +
-            `s=byFullySpecifiedName&locale=en&name=${conceptName}&v=bahmni`;
+            `s=byFullySpecifiedName&name=${conceptName}&v=bahmni`;
   }
 
   bahmniFormTranslateUrl(formName, formVersion, locale, formUuid) {

--- a/test/form-builder/helpers/UrlHelper.spec.js
+++ b/test/form-builder/helpers/UrlHelper.spec.js
@@ -13,7 +13,7 @@ describe('UrlHelper', () => {
   it('should return full concept representation', () => {
     const conceptRepresentation = urlHelper.getFullConceptRepresentation('someConcept');
     const expectedUrl = '/openmrs/ws/rest/v1/concept?' +
-        's=byFullySpecifiedName&locale=en&name=someConcept&v=bahmni';
+        's=byFullySpecifiedName&name=someConcept&v=bahmni';
     expect(conceptRepresentation).to.eql(expectedUrl);
   });
 


### PR DESCRIPTION
If we don’t pass locale information, the backend will take care of searching in both user and default locale.
backend code reference: https://github.com/Bahmni/bahmni-core/blob/master/bahmnicore-omod/src/main/java/org/bahmni/module/bahmnicore/web/v1_0/search/BahmniConceptSearchHandler.java#L54-L56