### PR TITLE
BAH-4113 | Fix. Bump Vulnerable Base Image Version

### DIFF
--- a/package/docker/Dockerfile
+++ b/package/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM httpd:2.4.59-alpine3.20
+FROM httpd:2.4.62-alpine3.20
 
 ADD dist/implementer_interface.zip /etc/implementer-interface/
 RUN unzip -d /usr/local/apache2/htdocs/implementer-interface /etc/implementer-interface/implementer_interface.zip


### PR DESCRIPTION
JIRA -> [BAH-4113](https://bahmni.atlassian.net/browse/BAH-4113)

This PR updates the base image for the implementer-interface Docker image from `httpd:2.4.59-alpine3.20` to `httpd:2.4.62-alpine3.20` to address security vulnerabilities identified in the previous version.

Changes:
Updated the Dockerfile to use `httpd:2.4.62-alpine3.20` as the base image.