### PR TITLE
BAH-4708: Upgrade implementer-interface Docker base image to fix CRITICAL vulnerabilities

### DIFF
--- a/package/docker/Dockerfile
+++ b/package/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM httpd:2.4.62-alpine3.20
+FROM httpd:2.4.67-alpine3.23
 
 ADD dist/implementer_interface.zip /etc/implementer-interface/
 RUN unzip -d /usr/local/apache2/htdocs/implementer-interface /etc/implementer-interface/implementer_interface.zip


### PR DESCRIPTION
## Summary
- Bump implementer-interface Docker base image to `httpd:2.4.67-alpine3.23` to resolve the 5 CRITICAL Trivy findings reported in BAH-4708.

## Why
- `httpd:2.4.62-alpine3.20` carries 5 CRITICAL CVEs in bundled Alpine packages (per Trivy scan referenced in BAH-4708). The upgrade picks up patched OpenSSL / expat / APR / libxml2 / busybox versions shipped with Alpine 3.23.
- httpd 2.4.x is API/ABI-compatible across patch versions; this image only serves static assets, so behavioural risk is minimal.
- Multi-arch parity preserved (linux/amd64, linux/arm64).

## Test plan
- [ ] CI: `Build and Publish` workflow succeeds (Docker build for amd64 + arm64).
- [ ] CI: `yarn test` passes.
- [ ] Manual: Pull resulting image and verify the implementer-interface UI loads and serves assets correctly.
- [ ] Re-run Trivy on the new image and confirm the 5 CRITICAL findings are resolved.

## Out of scope (follow-up)
- Addressing HIGH/MEDIUM findings on the same image.
- Adding hadolint / Trivy scan steps to CI.
- BAH-4709 (Part 2) covers the same fix for other Bahmni images.